### PR TITLE
Change interface filter to cope with interfaces that do not have a hwaddr field

### DIFF
--- a/src/uuid.erl
+++ b/src/uuid.erl
@@ -300,14 +300,14 @@ hex_to_int(Hex) ->
 %% @doc Predicate function for filtering interfaces to use
 -spec filter_if({IfName::string(), IfConfig::list(tuple())}) -> true | false.
 filter_if({IfName, IfConfig}) ->
-    [HasHwAddr] =
+    HasHwAddr =
         [true || {IfConfigItem, _} <- IfConfig, IfConfigItem =:= hwaddr],
 
     case {IfName, HasHwAddr} of
         % do not use loopback interface
         {"lo", _}     -> false;
         % use interface with a hwaddr
-        {_   , true}  -> true;
+        {_   , [true]}  -> true;
         % do not use interfaces without a hwaddr
         _             -> false
     end.


### PR DESCRIPTION
On EC2 (maybe elsewhere too) calls to `inet:getifaddrs()` gives an interface that do not have a `hwaddr` field. When one of these is encountered the list comprehension in `filter_if` returns the empty list which fails the match with `[HasHwAddr]` at line 303. 

The block of code that by comments would handle that case never gets reached. This patch matches the whole List rather than the value, meaning that the intended block gets hit with an empty list.
