### PR TITLE
Fix R18 warning about erlang:now() deprecated

### DIFF
--- a/src/uuid.app.src
+++ b/src/uuid.app.src
@@ -1,6 +1,6 @@
 {application, uuid,
  [{description, "Erlang UUID"},
-  {vsn, "0.4.7"},
+  {vsn, "0.4.7.1"},
   {modules, [uuid]},
   {registered, []},
   {applications, [stdlib, crypto]},

--- a/src/uuid.erl
+++ b/src/uuid.erl
@@ -98,7 +98,7 @@ uuid1_time() ->
     %% Transform unix epoch to 100 nanosecond intervals since 15 October 1582
     %% by adding offset to unix epoch and transforming microseconds epoch to
     %% nanoseconds.
-    {MegaSeconds, Seconds, MicroSeconds} = now(),
+    {MegaSeconds, Seconds, MicroSeconds} = os:timestamp(),
     UnixEpoch =
         (MegaSeconds * 1000000000000 + Seconds * 1000000 + MicroSeconds),
     Timestamp = ?nanosecond_intervals_offset +


### PR DESCRIPTION
Hi, here is a simple fix that should eliminate R18 compilation warning about erlang:now() deprecation. 